### PR TITLE
增加一个滑动返回判断条件

### DIFF
--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.h
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.h
@@ -55,4 +55,8 @@
 /// Default to NO, bars are more likely to show.
 @property (nonatomic, assign) BOOL fd_prefersNavigationBarHidden;
 
+/// Threshold to decide whether the interactive pop is enable;
+/// Default to 0, work then pointX bigger than 0.
+@property (nonatomic, assign) CGFloat fd_interactivePopMaxEnablePointX;
+
 @end

--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
@@ -55,6 +55,14 @@
         return NO;
     }
     
+    // Prevent calling the handler when the gesture start point bigger than the threshold.
+    if (topViewController.fd_interactivePopMaxEnablePointX > 0) {
+        CGPoint location = [gestureRecognizer locationInView:gestureRecognizer.view];
+        if (location.x > topViewController.fd_interactivePopMaxEnablePointX) {
+            return NO;
+        }
+    }
+    
     return YES;
 }
 
@@ -222,6 +230,21 @@ typedef void (^_FDViewControllerWillAppearInjectBlock)(UIViewController *viewCon
 - (void)setFd_prefersNavigationBarHidden:(BOOL)hidden
 {
     objc_setAssociatedObject(self, @selector(fd_prefersNavigationBarHidden), @(hidden), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+
+- (CGFloat)fd_interactivePopMaxEnablePointX
+{
+#if CGFLOAT_IS_DOUBLE
+    return [objc_getAssociatedObject(self, _cmd) doubleValue];
+#else
+    return [objc_getAssociatedObject(self, _cmd) floatValue];
+#endif
+}
+
+- (void)setFd_interactivePopMaxEnablePointX:(CGFloat)pointX
+{
+    objc_setAssociatedObject(self, @selector(fd_interactivePopMaxEnablePointX), @(pointX), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end


### PR DESCRIPTION
增加一个变量 fd_interactivePopMaxEnablePointX 判断是否开启滑动返回。
默认不判断，当 fd_interactivePopMaxEnablePointX 大于 0 时， 需要滑动手势的起始x坐标小于等于设定的阈值，才开启滑动返回效果。