### PR TITLE
fix a crash on old devices with slow animations

### DIFF
--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
@@ -166,7 +166,9 @@ typedef void (^_FDViewControllerWillAppearInjectBlock)(UIViewController *viewCon
     [self fd_setupViewControllerBasedNavigationBarAppearanceIfNeeded:viewController];
     
     // Forward to primary implementation.
-    [self fd_pushViewController:viewController animated:animated];
+    if (![self.topViewController isKindOfClass:[viewController class]]) {
+        [self fd_pushViewController:viewController animated:animated];
+    }
 }
 
 - (void)fd_setupViewControllerBasedNavigationBarAppearanceIfNeeded:(UIViewController *)appearingViewController


### PR DESCRIPTION
用了这个库上线之后，在旧的机器上面会造成crash。
![qq20150627-1 2x](https://cloud.githubusercontent.com/assets/3734851/8392132/34b9ddf0-1d12-11e5-9b83-43c4c9f778da.png)

参考网址：http://stackoverflow.com/questions/7083124/pushing-the-same-view-controller-instance-more-than-once-is-not-supported-exce