### PR TITLE
Patch 1

### DIFF
--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
@@ -86,7 +86,10 @@
         CGPoint locationInScrollView = [otherGestureRecognizer locationInView:scrollView];
         CGPoint locationInLayoutContainer = [gestureRecognizer.view convertPoint:locationInScrollView fromView:scrollView];
         UIViewController *topViewController = self.navigationController.viewControllers.lastObject;
-        return locationInLayoutContainer.x < MIN(100, topViewController.fd_interactivePopMaxAllowedInitialDistanceToLeftEdge);
+        if (topViewController.fd_interactivePopMaxAllowedInitialDistanceToLeftEdge > 0) {
+            return locationInLayoutContainer.x < MIN(100,topViewController.fd_interactivePopMaxAllowedInitialDistanceToLeftEdge);
+        }
+        return locationInLayoutContainer.x < 100;
     }
     return NO;
 }

--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
@@ -65,6 +65,31 @@
     return YES;
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    if ([otherGestureRecognizer isKindOfClass:NSClassFromString(@"UIScrollViewPanGestureRecognizer")]) {
+        return [self gestureRecognizer:gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:otherGestureRecognizer];
+    }
+    return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    if ([otherGestureRecognizer isKindOfClass:NSClassFromString(@"UIScrollViewPanGestureRecognizer")]) {
+        UIScrollView *scrollView = (UIScrollView *)otherGestureRecognizer.view;
+        if (![scrollView isKindOfClass:[UIScrollView class]]) {
+            return NO;
+        }
+        if (!scrollView.scrollEnabled) {
+            return NO;
+        }
+        CGPoint locationInScrollView = [otherGestureRecognizer locationInView:scrollView];
+        CGPoint locationInLayoutContainer = [gestureRecognizer.view convertPoint:locationInScrollView fromView:scrollView];
+        return locationInLayoutContainer.x < 100;
+    }
+    return NO;
+}
+
 @end
 
 typedef void (^_FDViewControllerWillAppearInjectBlock)(UIViewController *viewController, BOOL animated);

--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
@@ -85,7 +85,8 @@
         }
         CGPoint locationInScrollView = [otherGestureRecognizer locationInView:scrollView];
         CGPoint locationInLayoutContainer = [gestureRecognizer.view convertPoint:locationInScrollView fromView:scrollView];
-        return locationInLayoutContainer.x < 100;
+        UIViewController *topViewController = self.navigationController.viewControllers.lastObject;
+        return locationInLayoutContainer.x < MIN(100, topViewController.fd_interactivePopMaxAllowedInitialDistanceToLeftEdge);
     }
     return NO;
 }


### PR DESCRIPTION
当与UIScrollView的滑动起冲突的时，
* 如果滑动的位置在屏幕的最左侧MIN(100, fd_interactivePopMaxAllowedInitialDistanceToLeftEdge)距离以内时，执行pop，scrollView的滑动不起作用
* 如果在MIN(100, fd_interactivePopMaxAllowedInitialDistanceToLeftEdge)以外，不执行pop，scrollView的滑动起作用