### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ And this property is **NO** by default.
 
 # Installation
 
-Use cocoapods  
+Use CocoaPods  
 
 ``` ruby
 pod 'FDFullscreenPopGesture', '1.1'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

