### PR TITLE
修复了在调用 iOS SDK 发送短信时，导航栏取消按钮消失的问题

### DIFF
--- a/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
+++ b/FDFullscreenPopGesture/UINavigationController+FDFullscreenPopGesture.m
@@ -180,6 +180,9 @@ typedef void (^_FDViewControllerWillAppearInjectBlock)(UIViewController *viewCon
     __weak typeof(self) weakSelf = self;
     _FDViewControllerWillAppearInjectBlock block = ^(UIViewController *viewController, BOOL animated) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
+        if ([strongSelf isKindOfClass:NSClassFromString(@"MFMessageComposeViewController")]) {
+            return;
+        }
         if (strongSelf) {
             [strongSelf setNavigationBarHidden:viewController.fd_prefersNavigationBarHidden animated:animated];
         }


### PR DESCRIPTION
调用系统发送短信接口时，右上角 取消 按钮消失，这个 request 修复了短信，暂没有发现其他的问题，可以先简单的这么修复，如果要做的好一些，应该考虑维护一个不要调用 setNavigationBarHidden: 方法的列表